### PR TITLE
add: replace-env script

### DIFF
--- a/mobile/Dockerfile
+++ b/mobile/Dockerfile
@@ -15,3 +15,8 @@ RUN npm run build
 FROM nginx:latest AS production
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
+
+COPY replace-env.sh /usr/local/bin/replace-env.sh
+RUN chmod +x /usr/local/bin/replace-env.sh
+
+ENTRYPOINT ["/usr/local/bin/replace-env.sh"]

--- a/mobile/replace-env.sh
+++ b/mobile/replace-env.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$APP_ENV_PREFIX" ]; then
+    echo "APP_ENV_PREFIX is not set. Exiting."
+    exit 1
+fi
+
+echo env;
+
+for i in $(env | grep "^$APP_ENV_PREFIX"); do
+    key=$(echo "$i" | cut -d '=' -f 1)
+    value=$(echo "$i" | cut -d '=' -f 2-)
+
+    echo "Replacing $key with $value"
+
+    # Замена в файлах, где находятся ваши скомпилированные Vite-ресурсы
+    find "/usr/share/nginx/html" -type f -exec sed -i 's|'"${key}"'|'"${value}"'|g' {} \;
+done


### PR DESCRIPTION

### Пример:
**При сборке:**
`docker build -t test-front-mobile-7 --build-arg VITE_API_BASE_URL=PREFIX_API_BASE_URL --build-arg BASE_URL=PREFIX_BASE_URL .`
Теперь переменные окружения VITE_API_BASE_URL и BASE_URL динамические и их значение должно быть присвоено при запуске контейнера

**При запуске контейнера:**
`docker run -e APP_ENV_PREFIX=PREFIX -e PREFIX_API_BASE_URL=https://office.5scontrol.com/ -e PREFIX_BASE_URL=/mobile/ -p 3000:80 test-front-mobile-7`